### PR TITLE
Contrast at dark mode and image loading

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -20,7 +20,8 @@ const featuredSponsors = DATA.sponsors.filter(
         class="brightness-100 dark:invert"
         height="40"
         width="200"
-      />
+        loading="eager"
+        />
     </a>
   </div>
   <svg class="h-6 w-6 cursor-pointer xl:hidden block"> </svg>

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -77,10 +77,10 @@ function hasEvent(speakerName: string): boolean {
               >
                 <div class="flex flex-row items-center gap-x-4 md:gap-x-10 ">
                   <div class="flex flex-col w-fit">
-                    <span class="text-sm text-blue-600 font-bold">
+                    <span class="text-sm text-blue-600 font-bold dark:text-light-background">
                       {item.start}
                     </span>
-                    <span class="text-sm text-blue-600 font-bold">
+                    <span class="text-sm text-blue-600 font-bold dark:text-light-background">
                       {item.end}
                     </span>
                   </div>


### PR DESCRIPTION
Improved contrast on dark mode for schedules times. For example:
![image](https://github.com/user-attachments/assets/edb25759-2084-4b6b-89f9-036fbd3c0f9f)

Also set logo image as eager loaded.