### PR TITLE
link and headers fix

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -42,9 +42,9 @@ import Socials from "./Socials.astro";
     {
       !!DATA.previousEditions.length && (
         <div class="flex flex-col gap-6 w-fit mx-auto">
-          <h5 class="text-center lg:text-left font-semibold text-lg">
+          <h2 class="text-center lg:text-left font-semibold text-lg">
             Previous Editions
-          </h5>
+          </h2>
           <ul class="flex flex-row flex-wrap gap-3 align-middle justify-center md:justify-start">
             {DATA.previousEditions.map((prevEd) => (
               <li>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -40,7 +40,7 @@ const featuredSponsors = DATA.sponsors.filter(
           <li class="mx-auto">
             <a
               aria-label="Go to Schedule"
-              href="#schedule"
+              href="/#schedule"
               class="px-3 h-full cursor-pointer grid place-content-center hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg w-fit"
             >
               Schedule

--- a/src/components/Speaker.astro
+++ b/src/components/Speaker.astro
@@ -31,9 +31,9 @@ const { speaker, index } = Astro.props;
   <div
     class="flex flex-col align-middle justify-center gap-1 md:gap-3 py-[0px] text-center lg:text-left"
   >
-    <p transition:name={`name-speaker-${index}`} class="text-2xl font-bold">
+    <h3 transition:name={`name-speaker-${index}`} class="text-2xl font-bold">
       {speaker.name}
-    </p>
+    </h3>
     {
       speaker.position !== undefined && (
         <span class="text-sm">{speaker.position}</span>

--- a/src/components/Speaker.astro
+++ b/src/components/Speaker.astro
@@ -31,9 +31,9 @@ const { speaker, index } = Astro.props;
   <div
     class="flex flex-col align-middle justify-center gap-1 md:gap-3 py-[0px] text-center lg:text-left"
   >
-    <h3 transition:name={`name-speaker-${index}`} class="text-2xl font-bold">
+    <p transition:name={`name-speaker-${index}`} class="text-2xl font-bold">
       {speaker.name}
-    </h3>
+    </p>
     {
       speaker.position !== undefined && (
         <span class="text-sm">{speaker.position}</span>

--- a/src/components/TeamMember.astro
+++ b/src/components/TeamMember.astro
@@ -27,10 +27,10 @@ const { member, index, kind } = Astro.props;
       width={200}
     />
   </a>
-  <p
+  <h3
     transition:name={`name-${kind}-${member.name}`}
     class="w-full text-2xl font-semibold text-center text-dark-background dark:text-light-background p-2"
   >
     {member.name}
-</p>
+</h3>
 </article>

--- a/src/components/TeamMember.astro
+++ b/src/components/TeamMember.astro
@@ -27,10 +27,10 @@ const { member, index, kind } = Astro.props;
       width={200}
     />
   </a>
-  <h4
+  <p
     transition:name={`name-${kind}-${member.name}`}
     class="w-full text-2xl font-semibold text-center text-dark-background dark:text-light-background p-2"
   >
     {member.name}
-  </h4>
+</p>
 </article>


### PR DESCRIPTION
Due to missing slash '/' when traversing through sponsor tab to schedule, the page got stuck in sponsor-page#schedule, which does not exist.

Also changed html tag for headers  to improve screen readers heading order.