### PR TITLE
fix: image optimization and load images at hall of fame

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import { Image } from "astro:assets";
 import Layout from "../layouts/Layout.astro";
 import { DATA } from "../data/data";
 import Speaker from "../components/Speaker.astro";
@@ -160,9 +161,11 @@ for (const [index, sponsor] of Object.entries(DATA.sponsors)) {
           <ul class="flex flex-row gap-2 flex-wrap items-stretch justify-center">
             {DATA.hallOfFame.map((speaker) => (
               <li class="flex-1 sm:flex-grow-0 min-w-fit bg-white dark:bg-dark-background flex flex-col gap-2 px-10 py-8 rounded-md bg-center bg-cover relative overflow-hidden select-none pointer-events-none">
-                <div
-                  class="w-full h-full absolute left-0 top-0 opacity-40 bg-no-repeat bg-center bg-cover"
-                  style={"background-image: url(" + speaker.picture + ")"}
+                <Image
+                  src={speaker.picture}
+                  alt=""
+                  inferSize={true}
+                  class="background-image"
                 />
                 <span class="text-center text-black dark:text-white font-extrabold z-10 drop-shadow-md">
                   {speaker.name}
@@ -498,3 +501,15 @@ for (const [index, sponsor] of Object.entries(DATA.sponsors)) {
     )
   }
 </Layout>
+
+<style>
+    .background-image {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0.4;
+  }
+</style>

--- a/src/pages/organizer/[organizer].astro
+++ b/src/pages/organizer/[organizer].astro
@@ -32,6 +32,7 @@ const organizerData = DATA.team.organizers[Number(organizer)];
             class="w-full max-w-[300px] mx-auto rounded-md border-8 border-blue-600 dark:border-blue-600 aspect-square object-cover"
             src={organizerData.picture}
             alt={`Picture of ${organizerData.name}`}
+            loading="eager"
             height={300}
             width={300}
           />

--- a/src/pages/staff/[staff].astro
+++ b/src/pages/staff/[staff].astro
@@ -36,6 +36,7 @@ if (!staffData) {
             class="w-full max-w-[300px] mx-auto rounded-md border-8 border-blue-600 dark:border-blue-600 aspect-square object-cover"
             src={staffData.picture}
             alt={`Picture of ${staffData.name}`}
+            loading="eager"
             height={300}
             width={300}
           />


### PR DESCRIPTION
Background images were always loaded no matter if they were reached, as background images are not lazy loaded by default at Astro, changed to `<Image />` with cover properties.
![image](https://github.com/user-attachments/assets/3ab03529-7c50-4127-8900-4f227dfcd67b)
Also found that a few images could be optimized, decreasing its size by a lot
`DSC_0064_946217a526.jpg` and `DSC_0354_ed0a6fac02.jpg` can be resized to x0.2 and x0.3 respectively without loosing too much quality and reducing its size by 3MB in total, though these modifications would be needed at the CMS